### PR TITLE
add k8s-dns-kube-dns-amd64:1.14.1

### DIFF
--- a/k8s-dns-kube-dns-amd64/Dockerfile
+++ b/k8s-dns-kube-dns-amd64/Dockerfile
@@ -1,0 +1,2 @@
+FROM gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.1
+MAINTAINER mritd <mritd@mritd.me>


### PR DESCRIPTION
经过我测试k8s-dns-kube-dns已经不能用了，我在官网找到 k8s-dns-kube-dns-amd64 并且亲自测试能用，希望您能采用！